### PR TITLE
新增博客：斯坦福小镇源码精读（记忆检索与执行时序）

### DIFF
--- a/source/_posts/斯坦福小镇源码精读-记忆检索与执行时序.md
+++ b/source/_posts/斯坦福小镇源码精读-记忆检索与执行时序.md
@@ -1,0 +1,615 @@
+---
+style: summer
+
+title: 斯坦福小镇源码精读：记忆检索是「加权和」不是「累乘」，以及那个并不存在的「广播」
+
+tags:
+  - 斯坦福小镇
+  - Generative Agents
+  - LLM
+  - 多智能体
+  - AI Agent
+  - 源码阅读
+  - 记忆机制
+---
+
+斯坦福小镇（Generative Agents）火了以后，全网出现了大量「源码拆解」「核心机制揭秘」。但只要你真的把官方仓库 [`joonspk-research/generative_agents`](https://github.com/joonspk-research/generative_agents) 翻一遍，再对一遍 UIST'23 的原论文，就会发现**流传最广的两个结论几乎都是错的**：
+
+1. 「记忆检索是新鲜度 × 重要度 × 相关性的**三重累乘**，任意一项趋近 0 整条记忆就塌陷」——官方根本不是相乘，是**加权求和**；
+2. 「行为靠 `act()` 广播、视图靠 `env.update()` 同步」——官方源码里**压根没有 `broadcast()` / `env.update()` 这套 API**。
+
+这篇不堆概念，直接贴官方源码逐行核对，把记忆流、检索打分、以及「Agent 之间到底怎么互相感知」三件事讲清楚。所有代码片段都来自官方仓库 `reverie/backend_server/` 目录，文末附确切文件路径。
+
+<!-- more -->
+
+> 说明：本文以官方源码 `main` 分支为准，并与原论文 *Generative Agents: Interactive Simulacra of Human Behavior*（Park et al., UIST 2023）交叉验证。凡是和「网传版本」冲突的地方，以源码为准。
+
+## 开篇 · 先建立整体心智模型：一个 Agent 怎么「活」一天
+
+第一次接触斯坦福小镇，先别急着钻代码。用一个比喻把骨架搭好，后面所有源码都是往这个骨架上挂的。
+
+**它本质是个「回合制模拟游戏」**——像文字版《模拟人生》：一张地图、几个小人（Agent）、一个时钟。时钟一格一格往前跳，每跳一格，每个小人轮流「想一想」该干嘛、往哪走，然后画面刷新。开跑前先记住这几件事：
+
+- **两个程序 + 递纸条**：后端（Python）是 Agent 的「大脑」，只思考不画画；前端（浏览器游戏）只画地图、挪小人。两者靠交换文件沟通——前端告诉后端「谁在哪」，后端回「下一步谁去哪、做什么、说什么」。
+- **时间是「游戏内时钟」**：每跳一步代表游戏里若干秒（示例配置 10 秒），和现实脱钩（一步在现实里可能要好几秒，因为要调大模型）。
+- **每个 Agent 一步做 5 件事**（认知链）：**感知 → 检索 → 规划 → 反思 → 执行**。白话版：看周围 → 想起相关记忆 → 决定干嘛（含要不要搭话）→ 偶尔提炼人生感悟 → 落成「下一格走哪」。
+- **记忆是核心**：经历被存成一条条记忆，思考时再按「相关性 + 重要性 + 新鲜度」挑几条出来用。
+- **Agent 之间不发消息**：而是把「我在干嘛」留在地图格子上，别人路过自己读；要对话时，由发起方一口气把整段对话生成好。
+
+下面就沿这条骨架逐块拆到源码级，并顺手戳破全网最流行的两个误解（检索「累乘塌陷」、行为「广播」）。**每个抽象点后面都配了真实代码 + 一个手算/场景小例子——看不懂代码不要紧，先抓例子。**
+
+## 一、先把坐标系建对：真实的架构长什么样
+
+很多解读上来就讲「记忆流」，但没先讲清楚代码是怎么组织的，于是后面越讲越偏。先看真实结构。
+
+整个项目分两半：
+
+- **后端 `reverie/backend_server/`**：Python，跑 Agent 的「大脑」（认知循环），不负责画面。
+- **前端 `environment/frontend_server/`**：Django + Phaser，负责地图渲染和角色移动。
+
+两边**不是函数调用，而是靠文件交换**：后端读前端写出的 `environment/{step}.json`（每个 Agent 当前坐标），算完后写出 `movement/{step}.json`（每个 Agent 下一步去哪、动作描述、对话）。这个细节后面讲「广播」时是关键。
+
+单个 Agent 的「大脑」是 `Persona` 类，它的认知主循环是 `move()`，顺序写得明明白白（`persona/persona.py`）：
+
+```python
+# persona/persona.py  —— Persona.move()，每个 step 每个 Agent 调一次
+def move(self, maze, personas, curr_tile, curr_time):
+    self.scratch.curr_tile = curr_tile
+    # ...（判断是不是新的一天，决定要不要做长期规划）...
+
+    # 认知主序列：感知 → 检索 → 规划 → 反思 → 执行
+    perceived = self.perceive(maze)
+    retrieved = self.retrieve(perceived)
+    plan      = self.plan(maze, personas, new_day, retrieved)
+    self.reflect()
+    return self.execute(maze, personas, plan)
+```
+
+记住这条链：**perceive → retrieve → plan → reflect → execute**。没有 `act()`，没有 `broadcast()`。
+
+Agent 的记忆也不是「三层」那么随意，而是三个**各自独立的模块**：
+
+| 模块 | 文件 | 作用 |
+| --- | --- | --- |
+| `Scratch` | `memory_structures/scratch.py` | 短期/工作记忆：当前动作、日程，以及一堆超参数 |
+| `MemoryTree`（空间记忆） | `memory_structures/spatial_memory.py` | 一棵 `world→sector→arena→game_object` 的树，记「世界里有什么、在哪」 |
+| `AssociativeMemory`（记忆流） | `memory_structures/associative_memory.py` | 论文里说的 Memory Stream，存所有 event / thought / chat |
+
+`Persona.__init__` 里能直接看到这三者：
+
+```python
+# persona/persona.py
+self.s_mem   = MemoryTree(f_s_mem_saved)        # 空间记忆（树）
+self.a_mem   = AssociativeMemory(f_a_mem_saved) # 记忆流（核心）
+self.scratch = Scratch(scratch_saved)           # 短期工作记忆
+```
+
+## 二、记忆流里一条「记忆」到底有哪些字段
+
+网传版本说一条记忆就四个字段：`content / timestamp / importance / embedding`。这是过度简化了。看官方 `ConceptNode` 的真实定义：
+
+```python
+# memory_structures/associative_memory.py
+class ConceptNode:
+    def __init__(self,
+                 node_id, node_count, type_count, node_type, depth,
+                 created, expiration,
+                 s, p, o,
+                 description, embedding_key, poignancy, keywords, filling):
+        self.node_id = node_id
+        self.type    = node_type        # thought / event / chat —— 注意有三种类型
+        self.depth   = depth            # 反思的层级：观察=0，反思越高层 depth 越大
+
+        self.created       = created
+        self.expiration    = expiration
+        self.last_accessed = self.created   # 关键：检索时会被更新
+
+        self.subject   = s              # 主
+        self.predicate = p              # 谓     —— 记忆是 (S,P,O) 三元组
+        self.object    = o              # 宾
+
+        self.description   = description
+        self.embedding_key = embedding_key  # 注意：存的是 key，不是向量本身
+        self.poignancy     = poignancy      # 重要度：官方叫 poignancy，不叫 importance
+        self.keywords      = keywords        # 关键词集合，给关键词检索用
+        self.filling       = filling         # 反思节点指向的证据节点
+```
+
+几个容易踩的点：
+
+- **不是单一 `content`，而是 `(subject, predicate, object)` 三元组 + 一句自然语言 `description`**。三元组是给关键词索引用的，`description` 才是给 embedding 和 prompt 用的。
+- **「重要度」官方叫 `poignancy`**，由 LLM 打 1–10 分（`perceive.py` 里的 `generate_poig_score`），不叫 importance。
+- **时间有三个**：`created`、`expiration`、`last_accessed`。新鲜度用的是 `last_accessed`，而且检索命中后会被刷新——这点后面打分要用到。
+- **embedding 不直接挂在节点上**，节点只存 `embedding_key`，真正的向量放在 `AssociativeMemory.embeddings` 这个大字典里（原始发布版用 OpenAI `text-embedding-ada-002`，1536 维）。这样同一句话的向量可以复用。
+
+记忆流本身就是三条按时间排好的链表 + 关键词倒排索引：
+
+```python
+# memory_structures/associative_memory.py  —— AssociativeMemory.__init__
+self.seq_event   = []   # 事件流
+self.seq_thought = []   # 反思/想法流
+self.seq_chat    = []   # 对话流
+
+self.kw_to_event   = dict()  # 关键词 -> 事件节点列表（倒排索引）
+self.kw_to_thought = dict()
+self.kw_to_chat    = dict()
+```
+
+## 三、检索其实有「两条路」，三重打分只在其中一条上
+
+这是被讲得最混乱的部分。官方 `retrieve.py` 里其实有两个完全不同的函数。
+
+### 路径 A：感知驱动的检索 `retrieve()` —— 靠关键词，不打分
+
+主循环里 `self.retrieve(perceived)` 调的是这个。它对每个「刚感知到的事件」，按三元组里的词去倒排索引里捞相关记忆：
+
+```python
+# persona/cognitive_modules/retrieve.py
+def retrieve(persona, perceived):
+    retrieved = dict()
+    for event in perceived:
+        retrieved[event.description] = dict()
+        retrieved[event.description]["curr_event"] = event
+        # 用 (s, p, o) 去关键词索引里捞相关 event / thought
+        retrieved[event.description]["events"]   = list(
+            persona.a_mem.retrieve_relevant_events(
+                event.subject, event.predicate, event.object))
+        retrieved[event.description]["thoughts"] = list(
+            persona.a_mem.retrieve_relevant_thoughts(
+                event.subject, event.predicate, event.object))
+    return retrieved
+```
+
+而 `retrieve_relevant_events` 干的事极其朴素——**就是关键词查倒排表，没有向量、没有打分**：
+
+```python
+# memory_structures/associative_memory.py
+def retrieve_relevant_events(self, s_content, p_content, o_content):
+    contents = [s_content, p_content, o_content]
+    ret = []
+    for i in contents:
+        if i in self.kw_to_event:
+            ret += self.kw_to_event[i]
+    return set(ret)
+```
+
+所以「召回阶段」根本不是「向量相似度召回 Top100」，而是**关键词命中**。
+
+### 路径 B：焦点驱动的检索 `new_retrieve()` —— 这里才有三重打分
+
+真正的「新鲜度/重要度/相关性」三因子，在 `new_retrieve(persona, focal_points, n_count=30)` 里。它被**反思、规划、对话**调用（`reflect.py`、`plan.py`、`converse.py`），用一个「焦点问题」去整个记忆流里捞最相关的若干条。
+
+先看三个分量怎么算：
+
+```python
+# persona/cognitive_modules/retrieve.py
+
+# 新鲜度：对「按 last_accessed 排好序的节点」按排名做指数衰减
+def extract_recency(persona, nodes):
+    recency_vals = [persona.scratch.recency_decay ** i
+                    for i in range(1, len(nodes) + 1)]   # recency_decay 默认 0.99
+    recency_out = {}
+    for count, node in enumerate(nodes):
+        recency_out[node.node_id] = recency_vals[count]
+    return recency_out
+
+# 重要度：直接取节点的 poignancy（LLM 之前打的 1–10）
+def extract_importance(persona, nodes):
+    return {node.node_id: node.poignancy for node in nodes}
+
+# 相关性：焦点句的 embedding 与每条记忆 embedding 的余弦相似度
+def extract_relevance(persona, nodes, focal_pt):
+    focal_embedding = get_embedding(focal_pt)
+    relevance_out = {}
+    for node in nodes:
+        node_embedding = persona.a_mem.embeddings[node.embedding_key]
+        relevance_out[node.node_id] = cos_sim(node_embedding, focal_embedding)
+    return relevance_out
+```
+
+注意新鲜度的真实实现：它不是网传的 `1 / (0.01·Δt + 1)`，而是**对按 `last_accessed` 排序后的节点，按排名 `i` 做 `0.99^i` 的指数衰减**（论文里写的是按「沙盒游戏内小时数」衰减、衰减因子 0.995；开源代码改成了按排名、0.99，二者实现并不完全一致）。而且这里的**排序方向**藏着一个反直觉的坑——本节末尾专门拆（见「深挖：新鲜度排序方向其实是反的」）。
+
+### 关键：三个分量是「加权和」，不是「累乘」
+
+这是全文最重要的一段。把官方计算最终分数的代码原样贴出来：
+
+```python
+# persona/cognitive_modules/retrieve.py  —— new_retrieve() 内部
+recency_out   = normalize_dict_floats(extract_recency(persona, nodes), 0, 1)
+importance_out= normalize_dict_floats(extract_importance(persona, nodes), 0, 1)
+relevance_out = normalize_dict_floats(extract_relevance(persona, nodes, focal_pt), 0, 1)
+
+# gw = [1, 1, 1]
+# gw = [1, 2, 1]
+gw = [0.5, 3, 2]            # ← 官方当前启用的权重
+master_out = dict()
+for key in recency_out.keys():
+    master_out[key] = (persona.scratch.recency_w   * recency_out[key]   * gw[0]
+                     + persona.scratch.relevance_w * relevance_out[key] * gw[1]
+                     + persona.scratch.importance_w* importance_out[key]* gw[2])
+```
+
+看清楚连接符号是 `+`，不是 `*`。这和原论文完全一致：
+
+> score = α_recency · recency + α_importance · importance + α_relevance · relevance，
+> 论文实现里所有 α 都取 1。
+
+所以网传那套「**累乘塌陷**」的论证——「3 个月前一条 importance=10 的核心记忆，因为新鲜度趋近 0，三项一乘总分归零，于是被永久遗忘」——是建立在一个**根本不存在的乘法**上的。加权和里，某一项为 0 只是少加一块，另外两项照样把分数顶上去，不会「归零」。
+
+更有意思的是，网传的「优化方案」是「把累乘换成加权求和、弱化时间影响」。可官方**本来就是加权和**，而且：
+
+- `scratch.py` 默认 `recency_w = relevance_w = importance_w = 1`；
+- `retrieve.py` 里再乘一层 `gw = [0.5, 3, 2]`。
+
+合起来，三项的有效权重是 **新鲜度 0.5、相关性 3、重要度 2**。也就是说，官方**早就把新鲜度压到了最低权重**，相关性和重要度才是主导。网传方案兜了一圈，得到的正是官方已有的设计。
+
+### 示例：手算一次打分（看懂"加 ≠ 乘"）
+
+设 Isabella 在规划，焦点问题 =「我该怎么筹备情人节派对？」，记忆流里有 4 条候选（真实代码对**所有**记忆都算，这里取 4 条便于手算）。三项分各自归一化到 0–1 后：
+
+| 记忆 | 新鲜度ᴺ | 相关性ᴺ | 重要度ᴺ | 加权和 `0.5R+3Rel+2Imp` |
+| --- | :---: | :---: | :---: | :---: |
+| M1 我正在筹备派对 | 0.80 | 1.00 | 1.00 | **5.40** ① |
+| M4 Sam 说他可能来派对 | 0.60 | 0.81 | 0.56 | **3.85** ② |
+| M2 我热爱把大家聚到一起（很老的人格洞见） | 0.00 | 0.56 | 0.89 | **3.47** ③ |
+| M3 我今早喝了杯咖啡 | 1.00 | 0.00 | 0.00 | **0.50** ④ |
+
+那条**又老、又很久没用过的人格洞见 M2，仍拿 3.47 稳稳入选**；而"刚喝咖啡"的废话 M3 垫底。这正是我们想要的。
+
+可要是按网传的**累乘** `R×Rel×Imp` 呢？M2 = `0.00 × 0.56 × 0.89 = 0` 💥——只因新鲜度=0，它 0.89 的高重要度、0.56 的相关性全被"一票否决"，彻底丢失。这就是"累乘塌陷"的来历。**官方是加法，M2 活得好好的；那个会塌陷的乘法根本不存在。**
+
+最后取多少条？是 `top_highest_x_values(master_out, n_count)`，`n_count` 默认 30；`converse.py` 里按场景用 15 / 25 / 50。**没有固定的「Top100 → Top10」两段漏斗**。命中后还会顺手刷新 `last_accessed`：
+
+```python
+master_out = top_highest_x_values(master_out, n_count)
+master_nodes = [persona.a_mem.id_to_node[key] for key in master_out.keys()]
+for n in master_nodes:
+    n.last_accessed = persona.scratch.curr_time   # 被检索到 = 变「新」
+```
+
+### 深挖：新鲜度排序方向其实是反的
+
+前面留了个坑：新鲜度按「排名」算，那排名是怎么排的？把 `new_retrieve` 里和排序相关的三步原样拆开看，会发现实现和直觉是反的。
+
+**第 1 步——收集 + 排序**（`new_retrieve`，第 224–228 行）：
+
+```python
+nodes = [[i.last_accessed, i]
+          for i in persona.a_mem.seq_event + persona.a_mem.seq_thought
+          if "idle" not in i.embedding_key]
+nodes = sorted(nodes, key=lambda x: x[0])   # 按 last_accessed 升序，无 reverse=
+nodes = [i for created, i in nodes]
+```
+
+`sorted(...)` 不带 `reverse=` 就是**升序**，排序键是 `last_accessed`。所以 `nodes[0]` 是「最后一次访问最早」的那条（**最旧**），`nodes[-1]` 是**最近访问过**的那条。（注释写的是 "sorting them by the datetime of creation"、解包变量也叫 `created`，但代码实际按 `last_accessed` 排——这一段本身就有点糙。）
+
+**第 2 步——按位置分配衰减权重**（`extract_recency`）：`recency_vals = [0.99¹, 0.99², …, 0.99ⁿ]` 是**单调递减**的，下标 0 拿到最大值 0.99，最后一个下标拿到最小值。而 `enumerate(nodes)` 把下标 0 给了 `nodes[0]`，也就是**最旧**那条。
+
+**第 3 步——归一化**到 [0,1]：min‑max 是单调变换，只改范围、**不改顺序**。
+
+三步组合：**最旧的记忆拿到最高新鲜度，刚访问过的记忆拿到最低**。我把这段逻辑**原样**跑在 5 条样本上（`recency_decay=0.99`）：
+
+```text
+node（按 last_accessed 排序）       原始 recency    归一化
+OLDEST_3monthsAgo（3个月前）          0.99000        1.000   ← 最高
+old                                   0.98010        0.746
+mid                                   0.97030        0.495
+recent                                0.96060        0.246
+JUST_ACCESSED_now（1分钟前）          0.95099        0.000   ← 最低
+```
+
+这和论文意图正好相反（论文：「最近访问的记忆得分更高，按距上次访问的游戏小时数做指数衰减」）。更微妙的是，检索命中后会**刷新** `last_accessed`（上面那段 `n.last_accessed = curr_time`），于是你刚捞出来的记忆会被推到列表末尾 → 下次反而拿到**最低**的新鲜度，等于反了两层。
+
+我把整个 `retrieve.py` grep 了一遍：**唯一**的 `reverse=True` 在 `top_highest_x_values` 里（给**最终分数**降序排、挑 Top‑N 用），节点排序这条链路里**没有任何 `reversed()`**。所以二手资料里那句「原版代码会 reverse 一下修正」，对照真实 `main` 分支并不成立。
+
+那这算 bug 吗？`decay ** i` 这个写法只有在「`i=1` 对应最近的节点」时才说得通，所以意图应该是「最近的拿最高权重」，和实现正好差了一次反转——更像疏漏，不像设计。但**实际影响有限**，因为前面算过：新鲜度有效权重只有 0.5，而相关性 3、重要度 2；归一化后新鲜度对总分的全部贡献至多 0.5，排序本就由相关性 + poignancy 主导。**模拟跑起来依旧合理，不是因为新鲜度算对了，而是因为它几乎不影响大局。**
+
+接着前面那张 M1–M4 表看「影响到底有多大」：把它们的新鲜度换成官方代码的真实算法（最旧的 M2 反而拿最高、最新的 M3 拿最低），相关性、重要度不变，再算一遍加权和——排名从 `M1 > M4 > M2 > M3` 变成 `M1 > M2 > M4 > M3`：**只有 M2、M4 对调，冠军和垫底纹丝不动，最终入选的还是那 3 条。** 方向虽然反了，但新鲜度权重只有 0.5，撼不动由相关性(3)+重要度(2)定下的大局——这就是"真有瑕疵、却基本无害"的实证。
+
+如果你要在此基础上二次开发、且确实在意「越近越优先」，一行就能修——在**且仅在一处**反转：`sorted(..., reverse=True)`、或 `enumerate(reversed(nodes))`、或把 `recency_vals` 倒着生成。只能改一处，改两处会互相抵消又反回去。
+
+**这个反转有别人指出过吗？** 我专门做了一轮全网交叉检索（官方 issue/PR、约三千个 fork、中英文博客与论坛）。据笔者检索所及，**公开渠道几乎无人讨论过这个排序方向问题**：官方 issue/PR 对 `recency` / `last_accessed` / `extract_recency` 零提及，唯一改动过 `retrieve.py` 的重构 PR #198 甚至把它一字不差照搬了，还加了句 `# ... most recent last` 的注释却没察觉方向是反的。网上反复出现的只有「累乘 vs 加权和」那个**另一回事**的误解（见本节开头），和这里的方向问题不能混为一谈。
+
+最耐人寻味的旁证是：**斯坦福作者自己 2024 年的重写版 [`StanfordHCI/genagents`](https://github.com/joonspk-research/genagents) 已经把这段悄悄改对了**——新版按**真实时间差**衰减，而不再按列表位置：
+
+```python
+# genagents/modules/memory_stream.py —— 新版 extract_recency
+max_timestep = max(node.last_retrieved for node in seq_nodes)
+recency_decay = 0.99
+for node in seq_nodes:
+    recency_out[node.node_id] = recency_decay ** (max_timestep - node.last_retrieved)
+# 最近检索的节点 last_retrieved == max_timestep → 0.99^0 = 1.0（最高），方向终于对了
+```
+
+GPTeam、AI Town、MetaGPT 等独立复刻也都改用「真实时间差」算新鲜度，结构上绕开了这个坑——但同样，**没有任何一处注释或 commit 说明原版是反的**。所以这更像一个「存在、被下游不断复制、被作者自己默默改对，却从未被公开指认」的实现细节。
+
+## 四、Agent 之间怎么互相感知、怎么对话？没有「广播」这回事
+
+网传版本里有一套 `env.broadcast()` 往 3×3 网格广播、`env.update()` 只做视图同步的说法。官方源码里**这两个方法都不存在**。真实机制是这样的：
+
+### 1）事件写在地图瓦片（maze tile）上
+
+后端主循环 `start_server()` 每个 step 先把所有 Agent 同步到前端给的新坐标，并**把每个人「当前在干什么」作为事件写到它所在的瓦片上**：
+
+```python
+# reverie.py  —— ReverieServer.start_server() 主循环（节选）
+for persona_name, persona in self.personas.items():
+    new_tile = (new_env[persona_name]["x"], new_env[persona_name]["y"])
+    self.personas_tile[persona_name] = new_tile
+    # 把旧瓦片上这个人的事件移除，再把它的当前事件写到新瓦片
+    self.maze.remove_subject_events_from_tile(persona.name, curr_tile)
+    self.maze.add_event_from_tile(
+        persona.scratch.get_curr_event_and_desc(), new_tile)
+```
+
+### 2）别的 Agent 靠 `perceive()` 主动「看」周围瓦片
+
+事件不是被推送给谁，而是**留在地图上**，谁路过、谁在视野范围内，谁自己去读。这就是 `perceive()`：
+
+```python
+# persona/cognitive_modules/perceive.py  —— perceive()（节选）
+# 1. 取视野半径 vision_r 内的瓦片
+nearby_tiles = maze.get_nearby_tiles(persona.scratch.curr_tile,
+                                     persona.scratch.vision_r)   # 默认 4
+
+# 2. 收集同一 arena 内、这些瓦片上的事件，按距离排序
+percept_events_list = sorted(percept_events_list, key=itemgetter(0))
+
+# 3. 只取最近的 att_bandwidth 条（注意力带宽，默认 3）
+for dist, event in percept_events_list[:persona.scratch.att_bandwidth]:
+    perceived_events += [event]
+
+# 4. 用 retention（默认 5）去重：最近见过的就不重复感知/入库
+latest_events = persona.a_mem.get_summarized_latest_events(persona.scratch.retention)
+if p_event not in latest_events:
+    # ... 算 poignancy、算 embedding，写入 a_mem ...
+```
+
+所以「感知」由三个超参数控制（都在 `scratch.py`）：
+
+- `vision_r = 4`：能看多远；
+- `att_bandwidth = 3`：一次最多注意几件事；
+- `retention = 5`：最近 N 条内见过就不重复记。
+
+**这是一套「拉取式」的感知，不是「推送式」的广播。** 网传那套 `broadcast` API，更像是 AI Town 等第三方复刻项目的设计，被安到了斯坦福原版头上——讽刺的是，网传版本一边说「别人的双广播是魔改」，一边自己用的也不是原版 API。
+
+### 3）前端只负责「把人画出来、把人挪过去」
+
+后端算完，写出 `movement/{step}.json`：
+
+```python
+# reverie.py  —— start_server()，写给前端的结果
+movements["persona"][persona_name] = {
+    "movement":    next_tile,                  # 下一步去哪
+    "pronunciatio": pronunciatio,              # 一个 emoji
+    "description":  description,                # 文字描述
+    "chat":         persona.scratch.chat,      # 对话内容（如果有）
+}
+curr_move_file = f"{sim_folder}/movement/{self.step}.json"
+with open(curr_move_file, "w") as outfile:
+    outfile.write(json.dumps(movements, indent=2))
+self.step += 1
+self.curr_time += datetime.timedelta(seconds=self.sec_per_step)
+```
+
+前端读到后让角色走过去，走到了再把新坐标写回 `environment/{step+1}.json`，进入下一轮。**前端确实只做渲染、不含任何 AI 逻辑**——这一点网传版本说对了，只是它把这件事安在了一个不存在的 `env.update()` 上。
+
+### 4）对话：不是「轮流发消息」，是发起方一次性生成整场
+
+上面讲的是「感知」。但两个 Agent 真要「说上话」，机制和绝大多数人想的都不一样——这也是连英文解读都讲不准的地方。
+
+当 A 在 `plan()` 阶段感知到 B，会先走一段**对话决策**（`plan.py`）：过一堆硬性闸门（没在睡、不是 23 点、双方都没在聊天、冷却期已过……），再调一次 LLM 问「该不该上去搭话」（`generate_decide_to_talk`，返回 yes/no）。
+
+一旦决定搭话，**整场对话由 A 在自己这一个回合里一次性生成完**（`converse.py` 的 `agent_chat_v2`），最多 8 个来回：
+
+```python
+# converse.py —— agent_chat_v2（节选）
+for i in range(8):                       # 最多 8 轮，每轮双方各一句
+    # A 这一句：从【A 自己】的记忆里检索 + 总结 A 对 B 的关系
+    retrieved = new_retrieve(init_persona, [target_persona.name], 50)
+    relationship = generate_summarize_agent_relationship(init_persona, target_persona, retrieved)
+    utt, end = generate_one_utterance(maze, init_persona, target_persona, retrieved, curr_chat)
+    curr_chat += [[init_persona.name, utt]]
+    if end: break
+    # B 这一句：注意改成从【B 自己】的记忆检索、总结【B】对 A 的关系认知
+    retrieved = new_retrieve(target_persona, [init_persona.name], 50)
+    relationship = generate_summarize_agent_relationship(target_persona, init_persona, retrieved)
+    utt, end = generate_one_utterance(maze, target_persona, init_persona, retrieved, curr_chat)
+    curr_chat += [[target_persona.name, utt]]
+    if end: break
+```
+
+**最反直觉的点**：虽然是同一个进程在跑，但生成「B 说的那句」时，代码是去 **B 自己的记忆**里检索、并总结 **B 对 A 的关系认知**——所以每句话仍然扎根「说话人自己」的记忆，**不是 A 替 B 瞎编**。（注：`v1` 和更早的「一次出整段」`run_gpt_prompt_create_conversation` 都被注释掉了，当前走的是 `v2`，注释自述「optimized for speed via batch generation」。）
+
+生成好后，完整对话 + 「正在和对方聊天、持续到某时刻」的状态，会被**同时写进 A 和 B 两个人**（`_chat_react`）：
+
+```python
+# plan.py —— _chat_react（节选）
+convo, duration_min = generate_convo(maze, init_persona, target_persona)   # 整场对话
+convo_summary = generate_convo_summary(init_persona, convo)                # 概括成一条记忆
+for role, p in [("init", init_persona), ("target", target_persona)]:       # ← 写进【两个人】
+    chatting_with        = 对方.name
+    chatting_with_buffer = {对方.name: 800}        # 冷却值，防止马上再聊
+    _create_react(p, convo_summary, duration_min, ..., chatting_with, convo, ...)
+```
+
+于是等 B 在循环里轮到时，`_should_react` 第一行就因 `persona.scratch.chatting_with` 已被置上而直接返回 `False`——B 不再重新决策，直接执行这场已经生成好的对话。聊完那个 `chatting_with_buffer = 800` 会每步递减，冷却期内不会马上又凑上去，避免两人无限对话。
+
+### 5）谁先开口，取决于循环顺序
+
+于是网传那句「列表顺序影响相遇」其实**直觉没错，只是机制不是广播**。准确地说要拆成两半：
+
+- **位置/感知与顺序无关**：`start_server()` 先用**第一个循环**把所有 Agent 都摆到本 step 的新瓦片上，再用**第二个循环**让每个人 `move()`。等任何一个人开始感知时，所有人的位置在本 step 内已经定死，谁先 `perceive` 都看到相同位置；而且这些位置来自**前端上一 step 的结果**，天然带一个 step 的延迟（来自前后端文件往返，不是「刻意设计的时序差」）。
+- **但对话的发起强依赖顺序**：第二个循环是**串行**调用 `move()` 的（`for persona_name, persona in self.personas.items()`）。**谁先轮到、且通过 `generate_decide_to_talk` 判定，谁就成为发起方**，在自己回合里把整场对话和 `chatting_with` 状态直接写进对方；对方轮到时只能执行这场已生成好的对话。所以 `self.personas` 的迭代顺序，确实决定了「谁主动开口」。
+
+### 6）一个完整场景：Isabella 撞见 Klaus
+
+把感知和对话连起来走一遍。两人都在 Hobbs 咖啡馆，相距 2 格（在 `vision_r=4` 内）。
+
+**后端第一遍循环**：把两人摆到格子上，各自贴便条——Isabella 格子挂 `(Isabella, 筹备, 派对)`，Klaus 格子挂 `(Klaus, 写, 论文)`。
+
+**第二遍循环先轮到 Isabella**（`move()`）：
+
+| 阶段 | 发生了什么 |
+| --- | --- |
+| perceive | 扫视野，读到隔壁格子 `Klaus 在写论文`，收进记忆 |
+| retrieve | 用关键词「Klaus」捞出和他相关的旧记忆 |
+| plan | 当前事件主角是「Klaus」→ 闸门全过 → LLM 判定要不要搭话 → **yes** |
+| → `_chat_react` | `agent_chat_v2` **一次性生成整段对话**，写进 **Isabella 和 Klaus 两人** |
+| execute | 走向 Klaus，头顶 💬 |
+
+生成的对话（每句各扎根说话人自己的记忆）：
+
+```text
+Isabella: 嘿 Klaus！我在咖啡馆办情人节派对，来吗？      ← 出自 Isabella 记忆（她在筹备派对）
+Klaus:    听起来不错，我正埋在论文里，正好歇歇，算我一个。 ← 出自 Klaus 记忆（他在写论文）
+```
+
+**同一步轮到 Klaus 时**：`_should_react` 发现他的 `chatting_with` 已是 Isabella → 直接返回 `False`，不再决策，只**执行**这段已经生成好的对话。
+
+如果换成 Klaus 在 `self.personas` 里排在 Isabella 前面、又通过了判定，那就会是 **Klaus 发起**——这就是「谁先开口取决于循环顺序」。聊完那个 `chatting_with_buffer = 800` 会防止两人马上又粘上。
+
+## 五、认知模块细看：反思（Reflect）与规划（Plan）
+
+前面把记忆、检索、感知、对话都讲清楚了，但认知链里的 `reflect` 和 `plan` 还只是一笔带过。这一节补上——它们解释了 Agent 凭什么能「有人格地活一整天」，而不是每步随机乱走。顺带把**所有 LLM 调用共用的那套骨架**也讲了。
+
+### 1）反思 Reflect：攒够「感触」才停下来提炼
+
+反思不是每步都做，而是**经历累积到一定程度**才触发。每个 Agent 有个倒计时计数器，从 150 开始；每感知一件事，就按这件事的重要度（`poignancy`，LLM 打的 1–10 分）往下扣，扣到 ≤ 0 就反思：
+
+```python
+# scratch.py
+self.importance_trigger_max  = 150
+self.importance_trigger_curr = 150          # 倒计时
+# perceive.py：每感知一件事就扣它的 poignancy
+persona.scratch.importance_trigger_curr -= event_poignancy
+# reflect.py：扣到 0（且有记忆）就触发
+if persona.scratch.importance_trigger_curr <= 0 and 有记忆:
+    return True
+```
+
+越是经历「重磅」事件，越快触发反思。触发后分三步：
+
+1. **提焦点**：把最近的记忆拼成文本，问 LLM「这些信息里最值得问的 3 个高层问题是什么？」（`generate_focal_points`）。
+2. **捞素材**：对每个问题，用第三节那套加权和打分的 `new_retrieve` 捞相关记忆。
+3. **出洞见 + 记证据**：让 LLM 对每个问题给 5 条高层洞见，格式强制带「(because of 1, 5, 3)」——逼它说出**每条结论由哪几条记忆支撑**。
+
+洞见会被存成一种特殊的「想法（thought）」节点，关键在 `add_thought` 里的 `depth`：
+
+```python
+# associative_memory.py
+depth = 1
+if filling:                          # filling = 支撑这条洞见的证据节点
+    depth += max(证据节点们的 depth)   # 站在下层记忆的肩膀上
+```
+
+普通观察 `depth=0`，第一层反思 `depth=1`，**基于反思再反思 `depth=2、3…`**。于是记忆不是一摊平面，而是一棵**越往上越抽象**的树：「我今天又在咖啡馆写作」→「我热爱写作」→「我是个有创造力的人」。这正是 Agent 能形成并维持稳定人格的来源——也是真正该关注的「长期人设」抓手（远比新鲜度公式重要）。反思完计数器复位回 150。
+
+**示例**：Isabella 这几天的事件累计 poignancy 到 150 → 触发反思。提焦点（LLM）得到问题「Isabella 和咖啡馆社区是什么关系？」；检索捞到 `布置咖啡馆`(1)、`邀请 Klaus`(4)、`和 Maria 聊派对`(7) 等；LLM 出洞见 `Isabella loves bringing people together (because of 1, 4, 7)`，存成一个 `depth=1`、`filling=[1,4,7]` 的 thought 节点。**这条洞见正是前面检索示例里那条"很老的人格洞见 M2"的出处**——反思节点 poignancy 高，所以即便很久没用，也能在检索里活下来。
+
+### 2）规划 Plan：从一句话到「下一格走哪」的三级漏斗
+
+规划是个**从粗到细**的漏斗，跟人排日程一样。新的一天先定大框架：
+
+```python
+# plan.py：_long_term_planning
+wake_up_hour = generate_wake_up_hour(persona)                     # ① 几点起
+persona.scratch.daily_req = generate_first_daily_plan(...)        # ② 今天大致干嘛（broad strokes）
+persona.scratch.f_daily_schedule = generate_hourly_schedule(...)  # ③ 拆到每个小时
+persona.scratch.f_daily_schedule_hourly_org = f_daily_schedule[:] # 备份未拆的小时版
+```
+
+（注意有**两份日程**：`f_daily_schedule` 后面会被就地拆细，`f_daily_schedule_hourly_org` 保留原始小时版作参照。每天开头若非第一天，还会先 `revise_identity` 重写「现状 / 今日打算」——这是人设逐日演化的地方。）
+
+真要动手时，才把**当前这一小时**拆成 5 分钟一段（睡觉不拆、深夜不拆，省 token）：
+
+```python
+# plan.py：_determine_action
+if act_dura >= 60 and 需要拆:
+    f_daily_schedule[curr_index:curr_index+1] = generate_task_decomp(persona, act_desp, act_dura)
+```
+
+最后把抽象任务落到地图上的具体位置——三次级联 LLM 调用定位到「世界:区:场地:物件」，再配 emoji 和事件三元组：
+
+```python
+# plan.py：_determine_action
+act_world  = maze.access_tile(curr_tile)["world"]       # 世界取自脚下瓦片
+act_sector = generate_action_sector(act_desp, ...)      # 哪个区（家 / 咖啡馆…）
+act_arena  = generate_action_arena(act_desp, ...)       # 哪个场地（厨房 / 书房…）
+act_obj    = generate_action_game_object(act_desp, ...) # 哪个物件（书桌 / 床…）
+# → "the Ville:Isabella's house:bedroom:desk" + ✍️ + (Isabella, 写, 小说)
+```
+
+这份结果交给 `execute()`，就变成第一节里 `movement/{step}.json` 那份「下一格 + emoji + 描述」——**plan 和主循环在这里接上**。
+
+**示例**：Isabella 的一天怎么从一句话层层展开——
+
+```text
+① 粗日程: 7 点起 → 8 点开店 → 下午 1–5 点布置派对 → 5–7 点办派对 → 收拾睡觉
+② 小时表: 7–8 晨间例行 / 8–9 开店 / 9–12 招呼客人 / 13–17 布置派对 / ...
+③ 到 13:00 把"布置派对"这一小时拆成 5 分钟段: 收集材料(15min) → 挂横幅(30min) → 摆桌花(...) → ...
+④ "挂横幅"落到地图: "the Ville:Hobbs Cafe:cafe:wall" + 🎀 + (Isabella, decorating, cafe)
+```
+
+### 3）所有 LLM 调用共用的骨架：模板填空 + 校对重试
+
+斯坦福小镇里对 GPT 的每一次调用，都不是随手拼字符串，而是统一走「模板填空 → 调用 → 解析校对 → 出错重试」。模板是 `.txt` 文件，用 `!<INPUT i>!` 占位，且只取 `<commentblockmarker>###</commentblockmarker>` 之后的正文（之前是给人看的注释）。版本上 `v1`=GPT-3、`v2`=davinci、`v3_ChatGPT`=gpt-3.5-turbo 的 JSON 版。
+
+以反思洞见模板为例（`v2/insight_and_evidence_v1.txt`）：
+
+```text
+Input:
+!<INPUT 0>!
+
+What !<INPUT 1>! high-level insights can you infer from the above statements? (example format: insight (because of 1, 5, 3))
+1.
+```
+
+配套一定有个解析器，把 LLM 的自由文本抠成结构化结果——这就是「(because of 1,5,3)」存在的原因：
+
+```python
+# run_gpt_prompt.py：run_gpt_prompt_insight_and_guidance 的解析器
+def __func_clean_up(gpt_response, prompt=""):
+    ret = {}
+    for i in gpt_response.split("\n"):
+        row = i.split(". ")[-1]
+        thought = row.split("(because of ")[0].strip()        # 前半 = 洞见
+        evi_raw = row.split("(because of ")[1].split(")")[0]   # 后半 = 证据编号
+        ret[thought] = [int(x) for x in re.findall(r'\d+', evi_raw)]
+    return ret
+# 最多重试 5 次：拼输入 → 调用 → 校验 → 清洗，全失败返回兜底值
+output = safe_generate_response(prompt, gpt_param, 5, fail_safe, __func_validate, __func_clean_up)
+```
+
+看懂这段就看懂了整套系统的骨架：**模板出题 → GPT 作答 → 解析器按约定格式抠结构、抠不出就重试**。`reflect`、`plan`、对话生成——全是这一个模式的不同「填空题」而已。
+
+## 六、对照表 & 落地建议
+
+把网传结论和官方源码并排放一下：
+
+| 网传说法 | 官方源码 / 论文实际 |
+| --- | --- |
+| 检索分 = 新鲜度 × 重要度 × 相关性（累乘） | **加权和**：`0.5·recency + 3·relevance + 2·importance`（论文 α 全取 1） |
+| 累乘塌陷导致长期核心记忆丢失 | 不存在乘法，自然没有「归零」；且新鲜度权重最低（0.5） |
+| 优化方案：改成加权求和、弱化时间 | 官方本来就是加权和、本来就弱化时间 |
+| 新鲜度 = `1/(0.01·Δt+1)` | 按 `last_accessed` 排名做 `0.99^i` 指数衰减（论文是按游戏小时、0.995） |
+| 新鲜度让「越近的记忆分越高」 | 升序排 + 按位置赋权，实际**最旧的拿最高分**（方向反了，但权重仅 0.5，影响有限） |
+| 一条记忆 4 字段 | `ConceptNode`：SPO 三元组 + 三个时间戳 + poignancy + keywords + 类型/depth/filling |
+| Recall Top100 → Rerank Top10 | `new_retrieve(n_count=30)`，对话场景 15/25/50；无固定漏斗 |
+| `act()` 广播 / `env.update()` 同步 | 无此 API；事件写在 maze 瓦片上，邻居靠 `perceive()` 拉取 |
+| 认知链：感知→规划→行动→广播 | `perceive → retrieve → plan → reflect → execute` |
+| 两个 Agent 跨步轮流发消息对话 | 发起方在**一个回合内**用 `agent_chat_v2` 一次性生成整场（每句仍扎根各自记忆），再写进双方 |
+| 串行顺序无影响 / 靠前者先动后者看到新位置 | 位置与顺序无关；但**谁先开口由 `self.personas` 迭代顺序决定**（先手方代生成对话并写入双方） |
+
+如果你要在斯坦福小镇基础上做二次开发，几条**基于真实源码**的建议：
+
+1. **想调记忆行为，先调 `retrieve.py` 的 `gw` 和 `scratch.py` 的三个 `_w`**，而不是去「把累乘改成加权和」——它本来就是加权和。
+2. **长期人设漂移**的真正抓手是 `reflect.py`（反思把零散观察提炼成高 `poignancy`、低衰减影响的 thought 节点），以及 `poignancy` 的打分 prompt，而不是新鲜度公式。
+3. **新鲜度那段排序方向是反的**（最旧的拿最高分，见第三节「深挖」一节的实证）。如果你的场景很看重「最近发生」，按那一节给的一行改法反转一次即可——别默认它一定对。
+4. **跨 Agent 交互延迟一个 step**，是前后端文件往返带来的，不是 bug，但做实时性要求高的场景时要心里有数。
+
+---
+
+一句话总结：斯坦福小镇真正值得抄的，是 `perceive → retrieve → plan → reflect → execute` 这条认知链，和「记忆 = (S,P,O) + description + poignancy + embedding，检索 = 加权和打分」这套设计。至于网上那些「累乘塌陷」「广播时序」，看一眼源码就散了。
+
+> 参考：官方仓库 [`joonspk-research/generative_agents`](https://github.com/joonspk-research/generative_agents)；关键文件 `reverie/backend_server/persona/cognitive_modules/{retrieve,perceive,plan,reflect,converse}.py`、`persona/persona.py`、`persona/memory_structures/{associative_memory,scratch}.py`、`persona/prompt_template/{run_gpt_prompt,gpt_structure}.py` 及 `prompt_template/{v1,v2,v3_ChatGPT}/*.txt`、`reverie/backend_server/reverie.py`；作者 2024 年重写版 [`StanfordHCI/genagents`](https://github.com/joonspk-research/genagents)；论文 *Generative Agents: Interactive Simulacra of Human Behavior*（Park et al., UIST 2023, arXiv:2304.03442）。


### PR DESCRIPTION
## 内容
新增一篇技术博客，逐行对照官方仓库 `joonspk-research/generative_agents` 源码与 UIST'23 论文，精读斯坦福小镇（Generative Agents）：

- 整体架构与认知主循环 `perceive → retrieve → plan → reflect → execute`
- 记忆流结构 `ConceptNode` 与两条检索路径（关键词 vs 三因子打分）
- **检索打分是「加权和」不是「三重累乘」**：破除"累乘塌陷"误解，附 M1–M4 手算示例
- **新鲜度排序方向反转**的独家发现 + 全网交叉验证（连作者 2024 重写版都已悄悄改对）
- 角色间感知（地图瓦片 + `perceive` 拉取）与对话生成（`agent_chat_v2` 一次性生成整场）
- 反思（人格树）与规划（三级漏斗）+ 所有 LLM 调用共用的「模板填空 + 校对重试」骨架
- 面向小白的「先抽象 → 后具体 → 示例」组织方式

## 发布
站点已通过 `hexo deploy` 推送到 GitHub Pages；本 PR 提交对应的源 Markdown 以做版本控制与备份。

🤖 Generated with [Claude Code](https://claude.com/claude-code)